### PR TITLE
Added a Version Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# MageDeploy2
+[![GitHub version](https://badge.fury.io/gh/mwr%2Fmagedeploy2.svg)](https://badge.fury.io/gh/mwr%2Fmagedeploy2)
+
+# MageDeploy2 
 
 Magento2 Deployment Setup using Robo and Deployer.
 This repository contains tasks, a base Robo file, configuration etc.


### PR DESCRIPTION
Version Badge provides a consistent way for the GitHub community to learn about the GitHub repo associated with a particular Github repository and other documentation pages. Once the repo owner adds this badge to their README file, it will inform and link all visitors to the latest version of that repo.

To ensure prompt updates to your badge, please set up a webhook for your GitHub repo that points to:

`https://badge.fury.io/hooks/github`

https://badge.fury.io/for/gh/mwr/magedeploy2

