### PR TITLE
Fix crash/notice in case $opts array is not filled properly (e.g. wit…

### DIFF
--- a/src/Robo/RoboFile.php
+++ b/src/Robo/RoboFile.php
@@ -155,7 +155,10 @@ class RoboFile extends RoboTasks implements LoggerAwareInterface
             self::OPT_DEPLOYER_PARALLEL => false,
         ]
     ) {
-        $parallelMode = $opts[self::OPT_DEPLOYER_PARALLEL];
+        if(array_key_exists(self::OPT_DEPLOYER_PARALLEL, $opts))
+            $parallelMode = $opts[self::OPT_DEPLOYER_PARALLEL];
+        else
+            $parallelMode = false;
 
         $this->startTimer();
 


### PR DESCRIPTION
…hout p|paralell)

* Fixes "Notice: Undefined index: parallel|p in /workspace/vendor/mwltr/magedeploy2/src/Robo/RoboFile.php on line 158"